### PR TITLE
Function get() is added to Event Handler too, because sometimes user …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpiochip"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sebastian Reichel <sre@ring0.de>"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,17 @@ impl GpioEventHandle {
 
         Ok(())
     }
+
+    /// Get GPIO value
+    pub fn get(&self) -> io::Result<u8> {
+        let mut data = ioctl::gpiohandle_data { values: [0; 64] };
+
+        try!(from_nix_result(unsafe {
+            ioctl::get_line_values(self.file.as_raw_fd(), &mut data)
+        }));
+
+        Ok(data.values[0])
+    }
 }
 
 impl GpioHandle {


### PR DESCRIPTION
…want to actual status of the line.

For example, in my case I need to initiate transfer by SPI bus when GPIO line is high,
so I need to check is line in high state or wait for raising edge.